### PR TITLE
Only loop through the files in provided directory

### DIFF
--- a/check_s3_file_age.py
+++ b/check_s3_file_age.py
@@ -124,7 +124,7 @@ if (args.debug):
 
 #Loop through keys (files) in the S3 bucket and
 #check each one for min and max file age.
-for key in bucket.list():
+for key in bucket.list(prefix=bucketfolder):
     if (re.match(bucketfolder_regex,str(key.name))):
         if (args.listfiles):
             print '|' + str(key.storage_class) + '|' + str(key.name) + '|' \


### PR DESCRIPTION
Previously we were looping through bucket.list() regardlress if
you provided a sub-directory to check. bucket.list() returns all
the files in the root bucket. If we've provided a subdirectory
we only want to check those files.